### PR TITLE
Fix: process selection when modifier is released before mouse button (closes #22)

### DIFF
--- a/js/grabbit.js
+++ b/js/grabbit.js
@@ -374,12 +374,14 @@ document.addEventListener('mouseup', (e) => {
     }, { once: true });
   }
 
-  const mouseButton = getMouseButton(e);
-  const matchedAction = checkKeyCombination(e, mouseButton);
+  // Use the action that started (or was active during) the selection, not the current key state.
+  // This fixes the case where the user releases the modifier key (e.g. Ctrl) before releasing
+  // the mouse button — the selection should still be processed with the original action.
+  const actionToUse = GrabbitState.currentMatchedAction;
 
   // Process selected links only if selection was actually activated and there's a matched action
-  if (GrabbitState.isSelectionActive && matchedAction && GrabbitState.selectedLinks.size > 0) {
-    processSelectedLinks(matchedAction);
+  if (GrabbitState.isSelectionActive && actionToUse && GrabbitState.selectedLinks.size > 0) {
+    processSelectedLinks(actionToUse);
   }
 
   // Clean up


### PR DESCRIPTION
# Fix: Process selection when modifier is released before mouse button

Closes #22

## Problem

When using an activation key (Ctrl, Alt, Shift, etc.) + mouse click to start a drag selection, the user had to keep holding the modifier key until after releasing the mouse button. If the modifier was released first:

- The selection stayed visible (colored frame and highlighted links)
- Releasing the mouse button did nothing — no action was performed on the selected links

## Desired behavior

Once the selection is active and the colored frame is visible, the user should be able to release the keyboard modifier and continue dragging. The selection should still be processed with the originally assigned action when the user releases the mouse button.

## Solution

On **mouseup**, the code no longer re-checks the current key state to decide which action to run. It uses the action that was active when the selection started (or was last switched during the drag), stored in `GrabbitState.currentMatchedAction`. So:

1. User presses Ctrl + right-click and drags → selection activates with “Ctrl + Right Click” action
2. User releases Ctrl (selection frame stays, links stay highlighted)
3. User releases mouse button → selected links are processed with the Ctrl + Right Click action

## Changes

- **`js/grabbit.js`**: In the `mouseup` handler, use `GrabbitState.currentMatchedAction` for processing the selection instead of calling `checkKeyCombination(e, mouseButton)` with the mouseup event. Added a short comment explaining why.

## Testing

1. Set an action to e.g. Ctrl + Right Click (e.g. “Open in new tabs”).
2. Hold Ctrl, right-click, and drag to select links so the colored frame appears.
3. Release Ctrl while still holding the right mouse button.
4. Release the right mouse button.
5. **Expected:** Selected links open in new tabs (or whatever the action is). **Before fix:** Nothing happened.
